### PR TITLE
Fix for System.ValueTuple requirement under .NET 4.6.1.

### DIFF
--- a/Wu10Man/App.config
+++ b/Wu10Man/App.config
@@ -30,6 +30,10 @@
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Wu10Man/UserControls/DeclutterControl.xaml
+++ b/Wu10Man/UserControls/DeclutterControl.xaml
@@ -62,6 +62,7 @@
                 </ListView.ItemTemplate>
             </ListView>
             <Button Content="Remove Checked Apps" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="10" Width="150" Click="RemoveCheckedApps" />
+            <Button Content="Select All" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Width="150" Click="CheckAllApps" ToolTip="Checks and unchecks all items on the list." />
             
             <!--<Button x:Name="BlockAllHosts" Content="Block All Hosts" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Width="125" Click="BlockAllHosts_Click"/>-->
         </Grid>

--- a/Wu10Man/UserControls/DeclutterControl.xaml.cs
+++ b/Wu10Man/UserControls/DeclutterControl.xaml.cs
@@ -118,6 +118,18 @@ namespace WereDev.Utils.Wu10Man.UserControls
             _worker.RunWorkerAsync();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "_worker part of larger scope.")]
+        private void CheckAllApps(object sender, RoutedEventArgs e)
+        {
+            var packages = (PackageInfo[])ListViewWindowsApps.ItemsSource;
+            var allSelected = packages.Count(x => x.CheckedForRemoval).Equals(packages.Length);
+
+            foreach (var package in packages)
+            {
+                package.CheckedForRemoval = allSelected ? false : true;
+            }
+        }
+
         private void RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
             ShowMessage("Windows Apps have been removed.");

--- a/Wu10Man/Wu10Man.csproj
+++ b/Wu10Man/Wu10Man.csproj
@@ -106,6 +106,9 @@
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WPFSpark.1.4.0\lib\net461\System.Windows.Interactivity.dll</HintPath>

--- a/Wu10Man/packages.config
+++ b/Wu10Man/packages.config
@@ -14,5 +14,6 @@
   <package id="System.Security.Permissions" version="4.7.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="WPFSpark" version="1.4.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
It seems that another nuget package may be requiring this assembly, even though the main project is targeted at 4.6.1, so installing it from nuget will allow the .NET target version to remain unchanged.